### PR TITLE
Remove br element

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ Use the IDE of your choice (Webstorm recommended).
 
 ### Known issues
 
-<br>
-
 ___
 ## Copyright
 Copyright The GoDataSource-FrontEnd Contributors.


### PR DESCRIPTION
This PR removes the break line element '< br >' in the readme markdown.