### PR TITLE
Refactor user options filtering across models

### DIFF
--- a/src/app/core/services/helper/models/case-helper.model.ts
+++ b/src/app/core/services/helper/models/case-helper.model.ts
@@ -314,10 +314,10 @@ export class CaseHelperModel {
                 placeholder: () => 'LNG_CASE_FIELD_LABEL_RESPONSIBLE_USER_ID',
                 description: () => 'LNG_CASE_FIELD_LABEL_RESPONSIBLE_USER_ID_DESCRIPTION',
                 options: data.options.user
-                .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 .concat(
                   data.options.deletedUser
-                    .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                    .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 ),
                 value: {
                   get: () => data.itemData.responsibleUserId,
@@ -1585,7 +1585,7 @@ export class CaseHelperModel {
           this.visibleMandatoryKey,
           'responsibleUserId'
         ),
-        options: data.options.user,
+        options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
         sortable: true
       }, {
         type: V2AdvancedFilterType.MULTISELECT,

--- a/src/app/core/services/helper/models/contact-helper.model.ts
+++ b/src/app/core/services/helper/models/contact-helper.model.ts
@@ -321,10 +321,10 @@ export class ContactHelperModel {
                 placeholder: () => 'LNG_CONTACT_FIELD_LABEL_RESPONSIBLE_USER_ID',
                 description: () => 'LNG_CONTACT_FIELD_LABEL_RESPONSIBLE_USER_ID_DESCRIPTION',
                 options: data.options.user
-                .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 .concat(
                   data.options.deletedUser
-                    .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                    .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 ),
                 value: {
                   get: () => data.itemData.responsibleUserId,
@@ -1405,7 +1405,7 @@ export class ContactHelperModel {
           this.visibleMandatoryKey,
           'responsibleUserId'
         ),
-        options: data.options.user,
+        options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
         sortable: true
       }, {
         type: V2AdvancedFilterType.MULTISELECT,
@@ -1649,7 +1649,7 @@ export class ContactHelperModel {
             this.parent.followUp.visibleMandatoryKey,
             'responsibleUserId'
           ),
-          options: data.options.user,
+          options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
           relationshipPath: ['followUps'],
           relationshipLabel: 'LNG_CONTACT_FIELD_RELATIONSHIP_LABEL_FOLLOW_UPS'
         }, {
@@ -2342,7 +2342,7 @@ export class ContactHelperModel {
             this.parent.case.visibleMandatoryKey,
             'responsibleUserId'
           ),
-          options: data.options.user,
+          options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
           relationshipPath: ['relationships', 'people'],
           relationshipLabel: 'LNG_CONTACT_FIELD_RELATIONSHIP_LABEL_RELATIONSHIP_CASES',
           extraConditions: caseCondition

--- a/src/app/core/services/helper/models/contact-of-contact-helper.model.ts
+++ b/src/app/core/services/helper/models/contact-of-contact-helper.model.ts
@@ -312,10 +312,10 @@ export class ContactOfContactHelperModel {
                 placeholder: () => 'LNG_CONTACT_OF_CONTACT_FIELD_LABEL_RESPONSIBLE_USER_ID',
                 description: () => 'LNG_CONTACT_OF_CONTACT_FIELD_LABEL_RESPONSIBLE_USER_ID_DESCRIPTION',
                 options: data.options.user
-                .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 .concat(
                   data.options.deletedUser
-                    .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                    .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 ),
                 value: {
                   get: () => data.itemData.responsibleUserId,
@@ -999,7 +999,7 @@ export class ContactOfContactHelperModel {
           this.visibleMandatoryKey,
           'responsibleUserId'
         ),
-        options: data.options.user,
+        options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
         sortable: true
       }, {
         type: V2AdvancedFilterType.MULTISELECT,

--- a/src/app/core/services/helper/models/event-helper.model.ts
+++ b/src/app/core/services/helper/models/event-helper.model.ts
@@ -185,10 +185,10 @@ export class EventHelperModel {
               placeholder: () => 'LNG_EVENT_FIELD_LABEL_RESPONSIBLE_USER_ID',
               description: () => 'LNG_EVENT_FIELD_LABEL_RESPONSIBLE_USER_ID_DESCRIPTION',
               options: data.options.user
-                .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 .concat(
                   data.options.deletedUser
-                    .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                    .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 ),
               value: {
                 get: () => data.itemData.responsibleUserId,
@@ -535,7 +535,7 @@ export class EventHelperModel {
           this.visibleMandatoryKey,
           'responsibleUserId'
         ),
-        options: data.options.user,
+        options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
         sortable: true
       }, {
         type: V2AdvancedFilterType.MULTISELECT,

--- a/src/app/core/services/helper/models/follow-up-helper.model.ts
+++ b/src/app/core/services/helper/models/follow-up-helper.model.ts
@@ -128,10 +128,10 @@ export class FollowUpHelperModel {
                 placeholder: () => 'LNG_FOLLOW_UP_FIELD_LABEL_RESPONSIBLE_USER_ID',
                 description: () => 'LNG_FOLLOW_UP_FIELD_LABEL_RESPONSIBLE_USER_ID_DESCRIPTION',
                 options: data.options.user
-                .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 .concat(
                   data.options.deletedUser
-                    .filter(u => u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
+                    .filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(useToFilterOutbreak.id))
                 ),
                 value: {
                   get: () => data.itemData.responsibleUserId,
@@ -1097,7 +1097,7 @@ export class FollowUpHelperModel {
         ),
         notVisible: true,
         format: {
-          type: 'responsibleUser.nameAndEmail'
+          type: 'responsibleUser.name'
         },
         filter: {
           type: V2FilterType.MULTIPLE_SELECT,
@@ -1482,7 +1482,7 @@ export class FollowUpHelperModel {
             this.visibleMandatoryKey,
             'responsibleUserId'
           ),
-          options: data.options.user,
+          options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
           sortable: true
         }, {
           type: V2AdvancedFilterType.MULTISELECT,
@@ -1762,7 +1762,7 @@ export class FollowUpHelperModel {
             this.visibleMandatoryKey,
             'responsibleUserId'
           ),
-          options: data.options.user,
+          options: data.options.user.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(selectedOutbreak.id)),
           sortable: true
         }, {
           type: V2AdvancedFilterType.MULTISELECT,

--- a/src/app/core/services/resolvers/data/deleted-user.resolver.ts
+++ b/src/app/core/services/resolvers/data/deleted-user.resolver.ts
@@ -59,7 +59,7 @@ export class DeletedUserDataResolver implements IMapResolverV2<UserModel> {
 
             // add option
             response.options.push({
-              label: item.nameAndEmail,
+              label: item.name,
               value: item.id,
               data: item,
               disabled: item.deleted

--- a/src/app/core/services/resolvers/data/user.resolver.ts
+++ b/src/app/core/services/resolvers/data/user.resolver.ts
@@ -49,7 +49,7 @@ export class UserDataResolver implements IMapResolverV2<UserModel> {
 
             // add option
             response.options.push({
-              label: item.nameAndEmail,
+              label: item.name,
               value: item.id,
               data: item
             });

--- a/src/app/features/case/pages/cases-list/cases-list.component.ts
+++ b/src/app/features/case/pages/cases-list/cases-list.component.ts
@@ -1689,11 +1689,11 @@ export class CasesListComponent extends ListComponent<CaseModel, IV2ColumnToVisi
         ),
         notVisible: true,
         format: {
-          type: 'responsibleUser.nameAndEmail'
+          type: 'responsibleUser.name'
         },
         filter: {
           type: V2FilterType.MULTIPLE_SELECT,
-          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options,
+          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(this.selectedOutbreak.id)),
           includeNoValue: true
         },
         exclude: (): boolean => {

--- a/src/app/features/contact/pages/contact-daily-follow-ups-list/contact-daily-follow-ups-list.component.ts
+++ b/src/app/features/contact/pages/contact-daily-follow-ups-list/contact-daily-follow-ups-list.component.ts
@@ -1305,11 +1305,11 @@ export class ContactDailyFollowUpsListComponent extends ListComponent<FollowUpMo
         ),
         notVisible: true,
         format: {
-          type: 'responsibleUser.nameAndEmail'
+          type: 'responsibleUser.name'
         },
         filter: {
           type: V2FilterType.MULTIPLE_SELECT,
-          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options,
+          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(this.selectedOutbreak.id)),
           includeNoValue: true,
           value: this._workloadData?.user ?
             [this._workloadData.user] :

--- a/src/app/features/contact/pages/contacts-list/contacts-list.component.ts
+++ b/src/app/features/contact/pages/contacts-list/contacts-list.component.ts
@@ -1632,11 +1632,11 @@ export class ContactsListComponent
         ),
         notVisible: true,
         format: {
-          type: 'responsibleUser.nameAndEmail'
+          type: 'responsibleUser.name'
         },
         filter: {
           type: V2FilterType.MULTIPLE_SELECT,
-          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options,
+          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(this.selectedOutbreak.id)),
           includeNoValue: true
         },
         exclude: (): boolean => {

--- a/src/app/features/contacts-of-contacts/pages/contacts-of-contacts-list/contacts-of-contacts-list.component.ts
+++ b/src/app/features/contacts-of-contacts/pages/contacts-of-contacts-list/contacts-of-contacts-list.component.ts
@@ -1043,11 +1043,11 @@ export class ContactsOfContactsListComponent extends ListComponent<ContactOfCont
         ),
         notVisible: true,
         format: {
-          type: 'responsibleUser.nameAndEmail'
+          type: 'responsibleUser.name'
         },
         filter: {
           type: V2FilterType.MULTIPLE_SELECT,
-          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options,
+          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(this.selectedOutbreak.id)),
           includeNoValue: true
         },
         exclude: (): boolean => {

--- a/src/app/features/event/pages/events-list/events-list.component.ts
+++ b/src/app/features/event/pages/events-list/events-list.component.ts
@@ -647,11 +647,11 @@ export class EventsListComponent
         ),
         notVisible: true,
         format: {
-          type: 'responsibleUser.nameAndEmail'
+          type: 'responsibleUser.name'
         },
         filter: {
           type: V2FilterType.MULTIPLE_SELECT,
-          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options,
+          options: (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>).options.filter(u => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(this.selectedOutbreak.id)),
           includeNoValue: true
         },
         exclude: (): boolean => {

--- a/src/app/features/import-export-data/components/import-data/import-data.component.ts
+++ b/src/app/features/import-export-data/components/import-data/import-data.component.ts
@@ -733,6 +733,7 @@ export class ImportDataComponent
 
   // users
   users: IResolverV2ResponseModel<UserModel>;
+  userOptionsForMapping: ILabelValuePairModel[] = [];
   userNameAndEmailMap: {
     [name: string]: string;
   } = {};
@@ -1726,7 +1727,7 @@ export class ImportDataComponent
             // try to map by name
             if (this.userNameMap[sourceOptReduced]?.length === 1) {
               destinationOpt = this.userNameMap[sourceOptReduced][0];
-            } else if (this.users && this.users[sourceOption]) {
+            } else if (this.users.map[sourceOption] && this.userOptionsForMapping.some((u) => u.value === sourceOption)) {
               destinationOpt = sourceOption;
             }
           }
@@ -2577,9 +2578,13 @@ export class ImportDataComponent
 
     // users
     this.users = (this.activatedRoute.snapshot.data.user as IResolverV2ResponseModel<UserModel>);
+
+    // build filtered user options (selectedOutbreak may not be set yet in constructor; rebuilt in selectedOutbreakChanged)
+    this.rebuildUserOptionsForMapping();
+
     if (this.users?.list?.length) {
       this.users.list.forEach((item: UserModel) => {
-        // map name and email to id. the name with email pair is unique
+        // map name and email to id
         const userNameAndEmail: string = _.camelCase(item.nameAndEmail).toLowerCase();
         this.userNameAndEmailMap[userNameAndEmail] = item.id;
 
@@ -2594,6 +2599,25 @@ export class ImportDataComponent
         }
       });
     }
+  }
+
+  /**
+   * Rebuild filtered user options for import mapping.
+   * Called once on init and again when selectedOutbreak changes (async subscription).
+   */
+  private rebuildUserOptionsForMapping(): void {
+    const allUserOpts = this.users?.options || [];
+    const filteredUserOpts = (this.useOutbreakLocations && this.selectedOutbreak?.id)
+      ? allUserOpts.filter((u) => !u.data?.outbreakIds?.length || u.data?.outbreakIds?.includes(this.selectedOutbreak.id))
+      : allUserOpts;
+    this.userOptionsForMapping = filteredUserOpts.map((u) => ({
+      ...u,
+      label: u.label
+    }));
+  }
+
+  protected selectedOutbreakChanged(): void {
+    this.rebuildUserOptionsForMapping();
   }
 
   /**
@@ -3626,7 +3650,7 @@ export class ImportDataComponent
     } else if (this.languageFields[destinationField]) {
       return this.languages.options;
     } else if (this.userFields[destinationField]) {
-      return this.users.options;
+      return this.userOptionsForMapping;
     }
 
     // no template found
@@ -4131,7 +4155,7 @@ export class ImportDataComponent
     } else if (this.languageFields[destinationField] && this.languages.map[destinationOption]) {
       return this.languages.map[destinationOption].name;
     } else if (this.userFields[destinationField] && this.users.map[destinationOption]) {
-      return this.users.map[destinationOption].nameAndEmail;
+      return this.users.map[destinationOption].name;
     } else {
       // general dropdown
       return this.importableObject.modelPropertyValuesMapChildMap[destinationField] &&

--- a/src/app/features/import-export-data/import-export.module.routing.ts
+++ b/src/app/features/import-export-data/import-export.module.routing.ts
@@ -83,7 +83,8 @@ const routes: Routes = [
       savedImportPage: Constants.APP_IMPORT_PAGE.CASE.value
     },
     resolve: {
-      savedImportMapping: SavedImportMappingDataResolver
+      savedImportMapping: SavedImportMappingDataResolver,
+      user: UserDataResolver
     }
   },
 
@@ -131,7 +132,8 @@ const routes: Routes = [
       savedImportPage: Constants.APP_IMPORT_PAGE.CONTACT.value
     },
     resolve: {
-      savedImportMapping: SavedImportMappingDataResolver
+      savedImportMapping: SavedImportMappingDataResolver,
+      user: UserDataResolver
     }
   },
 
@@ -147,7 +149,8 @@ const routes: Routes = [
       savedImportPage: Constants.APP_IMPORT_PAGE.CONTACT_OF_CONTACT.value
     },
     resolve: {
-      savedImportMapping: SavedImportMappingDataResolver
+      savedImportMapping: SavedImportMappingDataResolver,
+      user: UserDataResolver
     }
   },
 

--- a/src/app/features/import-export-data/pages/import-case-data/import-case-data.component.html
+++ b/src/app/features/import-export-data/pages/import-case-data/import-case-data.component.html
@@ -11,6 +11,7 @@
     [model]="ImportServerModelNames.CASE"
     [fieldsWithoutTokens]="fieldsWithoutTokens"
     [addressFields]="addressFields"
+    [userFields]="userFields"
     [useOutbreakLocations]="true"
     [requiredDestinationFields]="requiredDestinationFields"
     [extraDataUsedToFormatData]="selectedOutbreak?.caseInvestigationTemplate"

--- a/src/app/features/import-export-data/pages/import-case-data/import-case-data.component.ts
+++ b/src/app/features/import-export-data/pages/import-case-data/import-case-data.component.ts
@@ -64,6 +64,10 @@ export class ImportCaseDataComponent implements OnInit, OnDestroy {
     'burialLocationId': true
   };
 
+  userFields = {
+    'responsibleUserId': true
+  };
+
   requiredDestinationFields: string[] = [
     'firstName'
   ];

--- a/src/app/features/import-export-data/pages/import-contact-data/import-contact-data.component.html
+++ b/src/app/features/import-export-data/pages/import-contact-data/import-contact-data.component.html
@@ -11,6 +11,7 @@
       [model]="ImportServerModelNames.CONTACT"
       [fieldsWithoutTokens]="fieldsWithoutTokens"
       [addressFields]="addressFields"
+      [userFields]="userFields"
       [useOutbreakLocations]="true"
       [requiredDestinationFields]="requiredDestinationFields"
       [extraDataUsedToFormatData]="selectedOutbreak?.contactInvestigationTemplate"

--- a/src/app/features/import-export-data/pages/import-contact-data/import-contact-data.component.ts
+++ b/src/app/features/import-export-data/pages/import-contact-data/import-contact-data.component.ts
@@ -63,6 +63,10 @@ export class ImportContactDataComponent implements OnInit, OnDestroy {
     'addresses[].locationId': true
   };
 
+  userFields = {
+    'responsibleUserId': true
+  };
+
   requiredDestinationFields: string[] = [
     'firstName',
     'relationship.persons[].id'

--- a/src/app/features/import-export-data/pages/import-contact-of-contact-data/import-contact-of-contact-data.component.html
+++ b/src/app/features/import-export-data/pages/import-contact-of-contact-data/import-contact-of-contact-data.component.html
@@ -11,6 +11,7 @@
     [model]="ImportServerModelNames.CONTACT_OF_CONTACT"
     [fieldsWithoutTokens]="fieldsWithoutTokens"
     [addressFields]="addressFields"
+    [userFields]="userFields"
     [useOutbreakLocations]="true"
     [requiredDestinationFields]="requiredDestinationFields"
     [asyncImport]="true">

--- a/src/app/features/import-export-data/pages/import-contact-of-contact-data/import-contact-of-contact-data.component.ts
+++ b/src/app/features/import-export-data/pages/import-contact-of-contact-data/import-contact-of-contact-data.component.ts
@@ -59,6 +59,10 @@ export class ImportContactOfContactDataComponent implements OnInit, OnDestroy {
     'addresses[].locationId': true
   };
 
+  userFields = {
+    'responsibleUserId': true
+  };
+
   requiredDestinationFields: string[] = [
     'firstName',
     'relationship.persons[].id'


### PR DESCRIPTION
Refactor user options filtering across models to include users without outbreak IDs; update responsible user display to show only names.
